### PR TITLE
Update Lucene core version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     junitJupiterVersion = '5.5.1'
     log4jVersion="2.13.3"
     log4jClassicVersion="1.2.3"
-    luceneCoreVersion = "8.5.2"
+    luceneCoreVersion = "8.7.0"
     mockitoVersion = '2.23.0'
     slf4jVersion = "1.7.30"
 }


### PR DESCRIPTION
Latest ElasticSearch version 7.10.1 uses Lucence 8.7.0.

"version" : {
&nbsp;&nbsp;&nbsp;&nbsp;"number" : "**7.10.1**",
&nbsp;&nbsp;&nbsp;&nbsp;"build_flavor" : "default",
&nbsp;&nbsp;&nbsp;&nbsp;"build_type" : "docker",
&nbsp;&nbsp;&nbsp;&nbsp;"build_hash" : "1c34507e66d7db1211f66f3513706fdf548736aa",
&nbsp;&nbsp;&nbsp;&nbsp;"build_date" : "2020-12-05T01:00:33.671820Z",
&nbsp;&nbsp;&nbsp;&nbsp;"build_snapshot" : false,
&nbsp;&nbsp;&nbsp;&nbsp;"lucene_version" : "**8.7.0**",
&nbsp;&nbsp;&nbsp;&nbsp;"minimum_wire_compatibility_version" : "6.8.0",
&nbsp;&nbsp;&nbsp;&nbsp;"minimum_index_compatibility_version" : "6.0.0-beta1"
}

When running Lucene Stats against Elasticsearch 7.10 directory, following exception is thrown.

`2021-01-28 10:45:15,948 Format version is not supported (resource BufferedChecksumIndexInput(MMapIndexInput(path="/home/elasticsearch/host/nodes/0/_state/segments_di"))): 10 (needs to be between 7 and 9)
org.apache.lucene.index.IndexFormatTooNewException: Format version is not supported (resource BufferedChecksumIndexInput(MMapIndexInput(path="/home/elasticsearch/host/nodes/0/_state/segments_di"))): 10 (needs to be between 7 and 9)
	at org.apache.lucene.codecs.CodecUtil.checkHeaderNoMagic(CodecUtil.java:216)
	at org.apache.lucene.index.SegmentInfos.readCommit(SegmentInfos.java:305)
	at org.apache.lucene.index.SegmentInfos.readCommit(SegmentInfos.java:289)
	at org.apache.lucene.index.StandardDirectoryReader$1.doBody(StandardDirectoryReader.java:64)
	at org.apache.lucene.index.StandardDirectoryReader$1.doBody(StandardDirectoryReader.java:61)
	at org.apache.lucene.index.SegmentInfos$FindSegmentsFile.run(SegmentInfos.java:680)
	at org.apache.lucene.index.StandardDirectoryReader.open(StandardDirectoryReader.java:84)
	at org.apache.lucene.index.DirectoryReader.open(DirectoryReader.java:76)
	at org.apache.lucene.index.DirectoryReader.open(DirectoryReader.java:64)
	at org.stapledon.lucene.ElasticsearchStateDecoder.decode(ElasticsearchStateDecoder.java:87)
	at org.stapledon.lucene.ElasticLuceneStats.process(ElasticLuceneStats.java:127)
	at org.stapledon.lucene.ElasticLuceneStats.main(ElasticLuceneStats.java:33)`

Updating Lucene core fixes the exception thrown